### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -2,6 +2,9 @@ name: Run linters
 
 on: [push]
 
+permissions:
+  contents: read
+
 jobs:
   linting:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/wozjac/vscode-ui5-odata-mock-generator/security/code-scanning/3](https://github.com/wozjac/vscode-ui5-odata-mock-generator/security/code-scanning/3)

To fix the issue, we need to add a `permissions` block to the workflow. Since the workflow is performing linting tasks and does not require write access, the permissions can be set to `contents: read`. This limits the `GITHUB_TOKEN` to read-only access, adhering to the principle of least privilege.

The `permissions` block should be added at the root level of the workflow file, ensuring that it applies to all jobs in the workflow. No additional imports, methods, or definitions are required for this fix.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
