### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,9 @@ name: Build
 
 on: [push]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     strategy:


### PR DESCRIPTION
Potential fix for [https://github.com/wozjac/vscode-ui5-odata-mock-generator/security/code-scanning/1](https://github.com/wozjac/vscode-ui5-odata-mock-generator/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Based on the workflow's steps, the `contents: read` permission is sufficient for most operations, and `pull-requests: write` may be required if the workflow interacts with pull requests. However, since the workflow does not explicitly modify pull requests, we will limit permissions to `contents: read`.

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or within the `build` job to scope permissions to that specific job. In this case, we will add it at the root level for simplicity.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
